### PR TITLE
feat: add 'impl FromIterator for Collection'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "2.2.1"
+version = "2.3.0"
 authors = ["Hove <core@hove.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -11,7 +11,7 @@ use std::{
     borrow::Borrow,
     cmp::Ordering,
     collections::{hash_map::Entry::*, HashMap},
-    iter,
+    iter::{self, FromIterator},
     marker::PhantomData,
     ops, slice,
 };
@@ -343,6 +343,22 @@ impl<T> IntoIterator for Collection<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.objects.into_iter()
+    }
+}
+
+impl<T> FromIterator<T> for Collection<T> {
+    /// Collect all items into a `Collection`.
+    ///
+    /// ```
+    /// use typed_index_collection::Collection;
+    ///
+    /// let c: Collection<isize> = vec![-2, -1, 0, 1, 2].into_iter().collect();
+    /// assert_eq!(*c.values().nth(1).unwrap(), -1);
+    /// ```
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self {
+            objects: iter.into_iter().collect(),
+        }
     }
 }
 


### PR DESCRIPTION
Note that I considered `impl FromIterator for CollectionWithId` too... but since this would need to `panic` in case multiple objects of the same identifier are part of the iterator (there is no possible error handling in `FromIterator` trait), I decided to not do it.

- [x] wait on #23 to be merged