### PR TITLE
fix: clippy is not happy with 'Clone' implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! Collections of objects with typed indices and buildin identifier support.
 
 #![deny(missing_docs)]
+// `derivative` does not implement `Clone` the correct way if it also implements `Copy`
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 
 mod collection;
 mod error;


### PR DESCRIPTION
Not sure it's ideal, it's basically a problem with how `derivative` implements `Clone` in presence of a `Copy` implementation too. An alternative solution would be the following patch.

![image](https://github.com/hove-io/typed_index_collection/assets/2520723/579d8254-2935-4383-be83-82f7d348a127)

I can go either way.

Note that the bug has been reported to `derivative` (see https://github.com/mcarton/rust-derivative/issues/112) and a simple fix for them would be to [add the `#[automatically_derivated]` to the implementations](https://github.com/mcarton/rust-derivative/issues/112#issuecomment-1687652732).